### PR TITLE
feat: Transform JSON-RPC server into a distributed gateway

### DIFF
--- a/iterative_udp/server.c
+++ b/iterative_udp/server.c
@@ -4,15 +4,75 @@
 #include <string.h>
 #include <unistd.h>
 #include <arpa/inet.h>
+#include <getopt.h> // Added for getopt_long
+#include <errno.h> // Added for errno
+#include <time.h>   // Added for timestamp logging
 
-#define PORT 8080
+// #define PORT 8080 // Will be set by command line argument
 #define BUF_SIZE 1024
 
-int main() {
+// Function for logging with timestamp (similar to TCP server)
+void log_with_timestamp(const char *msg) {
+    time_t now = time(NULL);
+    struct tm *t = localtime(&now);
+    char buf[64];
+    strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", t);
+    printf("[%s] %s\n", buf, msg);
+}
+
+
+int main(int argc, char *argv[]) { // Added argc and argv
     int sockfd;
     struct sockaddr_in server_addr, client_addr;
     socklen_t addr_len = sizeof(client_addr);
     char buffer[BUF_SIZE];
+
+    char *gateway_host = NULL;
+    int gateway_port = -1;
+    char *my_host = NULL;
+    int my_port = -1;
+    char *server_name = NULL;
+
+    // Parse command line arguments
+    struct option long_options[] = {
+        {"gateway-host", required_argument, 0, 'g'},
+        {"gateway-port", required_argument, 0, 'p'},
+        {"my-host", required_argument, 0, 'h'},
+        {"my-port", required_argument, 0, 'm'},
+        {"server-name", required_argument, 0, 's'},
+        {0, 0, 0, 0}
+    };
+
+    int opt;
+    while ((opt = getopt_long(argc, argv, "g:p:h:m:s:", long_options, NULL)) != -1) {
+        switch (opt) {
+            case 'g':
+                gateway_host = optarg;
+                break;
+            case 'p':
+                gateway_port = atoi(optarg);
+                break;
+            case 'h':
+                my_host = optarg;
+                break;
+            case 'm':
+                my_port = atoi(optarg);
+                break;
+            case 's':
+                server_name = optarg;
+                break;
+            default:
+                fprintf(stderr, "Usage: %s --gateway-host <host> --gateway-port <port> --my-host <host> --my-port <port> --server-name <name>\n", argv[0]);
+                exit(EXIT_FAILURE);
+        }
+    }
+
+    if (!gateway_host || gateway_port == -1 || !my_host || my_port == -1 || !server_name) {
+        fprintf(stderr, "Missing required arguments.\n");
+        fprintf(stderr, "Usage: %s --gateway-host <host> --gateway-port <port> --my-host <host> --my-port <port> --server-name <name>\n", argv[0]);
+        exit(EXIT_FAILURE);
+    }
+    log_with_timestamp("Server starting with provided arguments.");
 
     // Create UDP socket
     sockfd = socket(AF_INET, SOCK_DGRAM, 0);
@@ -23,56 +83,143 @@ int main() {
 
     // Setup server address
     memset(&server_addr, 0, sizeof(server_addr));
-    server_addr.sin_family = AF_INET; 
-    server_addr.sin_addr.s_addr = INADDR_ANY; 
-    server_addr.sin_port = htons(PORT);
+    server_addr.sin_family = AF_INET;
+    // server_addr.sin_addr.s_addr = INADDR_ANY; // Listen on all interfaces
+    server_addr.sin_port = htons(my_port); // Use my_port from command line
+
+    if (inet_pton(AF_INET, my_host, &server_addr.sin_addr) <= 0) {
+        perror("Invalid address/ Address not supported for server listening");
+        log_with_timestamp("Using INADDR_ANY for listening due to my_host issue for bind.");
+        server_addr.sin_addr.s_addr = INADDR_ANY; // Fallback
+    }
+
 
     // Bind the socket
     if (bind(sockfd, (const struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
         perror("Bind failed");
-        close(sockfd);
-        exit(1);
+        // If specific my_host bind fails, try INADDR_ANY as a fallback
+        log_with_timestamp("Bind to specific my_host failed, trying INADDR_ANY.");
+        server_addr.sin_addr.s_addr = INADDR_ANY;
+        if (bind(sockfd, (const struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
+            perror("Bind failed on INADDR_ANY as well");
+            close(sockfd);
+            exit(1);
+        }
     }
 
-    printf("UDP Calculator Server is running on port %d...\n", PORT);
+    char log_msg[256];
+    snprintf(log_msg, sizeof(log_msg), "UDP server listening on %s:%d...", my_host, my_port);
+    log_with_timestamp(log_msg);
+
+    // Register with gateway using a new temporary UDP socket
+    int reg_sock;
+    struct sockaddr_in gateway_addr_reg; // Use a different name to avoid conflict
+    char reg_msg[512];
+
+    snprintf(reg_msg, sizeof(reg_msg), "type=UDP;host=%s;port=%d;name=%s;ops=add,subtract,multiply,divide",
+             my_host, my_port, server_name);
+
+    if ((reg_sock = socket(AF_INET, SOCK_DGRAM, 0)) < 0) {
+        perror("Temporary UDP socket creation for registration failed");
+        // Log and continue without registration
+        log_with_timestamp("Proceeding without gateway registration due to socket creation failure.");
+    } else {
+        memset(&gateway_addr_reg, 0, sizeof(gateway_addr_reg));
+        gateway_addr_reg.sin_family = AF_INET;
+        gateway_addr_reg.sin_port = htons(gateway_port);
+
+        if (inet_pton(AF_INET, gateway_host, &gateway_addr_reg.sin_addr) <= 0) {
+            perror("Invalid gateway address for registration");
+            log_with_timestamp("Proceeding without gateway registration due to invalid gateway address.");
+            close(reg_sock);
+        } else {
+            log_with_timestamp("Attempting to register with gateway...");
+            if (sendto(reg_sock, reg_msg, strlen(reg_msg), 0, (const struct sockaddr *)&gateway_addr_reg, sizeof(gateway_addr_reg)) < 0) {
+                perror("sendto registration message failed");
+                char error_log[512];
+                snprintf(error_log, sizeof(error_log), "Failed to send registration to %s:%d. Error: %s", gateway_host, gateway_port, strerror(errno));
+                log_with_timestamp(error_log);
+            } else {
+                char success_log[512];
+                snprintf(success_log, sizeof(success_log), "Registration message sent to %s:%d: %s", gateway_host, gateway_port, reg_msg);
+                log_with_timestamp(success_log);
+            }
+            close(reg_sock); // Close the temporary socket
+        }
+    }
+
+
+    log_with_timestamp("UDP Calculator Server is now fully running.");
 
     while (1) {
         // Receive message
-        recvfrom(sockfd, buffer, BUF_SIZE, 0, (struct sockaddr *)&client_addr, &addr_len);
+        memset(buffer, 0, BUF_SIZE); // Clear buffer before receiving
+        int n = recvfrom(sockfd, buffer, BUF_SIZE -1 , 0, (struct sockaddr *)&client_addr, &addr_len);
+        if (n < 0) {
+            perror("recvfrom error");
+            continue;
+        }
+        buffer[n] = '\0'; // Null-terminate the received data
+
+        // Log client address and message
+        char client_ip[INET_ADDRSTRLEN];
+        inet_ntop(AF_INET, &client_addr.sin_addr, client_ip, INET_ADDRSTRLEN);
+        char recv_log[BUF_SIZE + 100];
+        snprintf(recv_log, sizeof(recv_log), "Received from %s:%d - %s", client_ip, ntohs(client_addr.sin_port), buffer);
+        log_with_timestamp(recv_log);
+
 
         int choice;
         double a, b, result;
-        sscanf(buffer, "%d %lf %lf", &choice, &a, &b);
+        // sscanf(buffer, "%d %lf %lf", &choice, &a, &b); // Original sscanf
+        if (sscanf(buffer, "%d %lf %lf", &choice, &a, &b) != 3) {
+            char err_resp[100];
+            snprintf(err_resp, sizeof(err_resp), "Invalid input format. Expected: <choice> <num1> <num2>");
+            log_with_timestamp("Sending error response for invalid input format.");
+            sendto(sockfd, err_resp, strlen(err_resp), 0, (struct sockaddr *)&client_addr, addr_len);
+            continue;
+        }
+
 
         // Handle operation
         if (choice == 5) {
-            printf("Client requested exit.\n");
+            log_with_timestamp("Client requested exit.");
+            char exit_resp[] = "Goodbye.";
+            sendto(sockfd, exit_resp, strlen(exit_resp), 0, (struct sockaddr *)&client_addr, addr_len);
             continue;
         }
+
+        char calc_log[100];
+        snprintf(calc_log, sizeof(calc_log), "Performing operation %d for %lf and %lf", choice, a,b);
+        log_with_timestamp(calc_log);
 
         switch (choice) {
             case 1: result = a + b; break;
             case 2: result = a - b; break;
             case 3: result = a * b; break;
-            case 4: 
+            case 4:
                 if (b == 0) {
+                    log_with_timestamp("Error: Division by zero.");
                     snprintf(buffer, BUF_SIZE, "Error: Division by zero");
                     sendto(sockfd, buffer, strlen(buffer), 0, (struct sockaddr *)&client_addr, addr_len);
                     continue;
                 }
-                result = a / b; 
+                result = a / b;
                 break;
             default:
-                snprintf(buffer, BUF_SIZE, "Invalid choice");
+                log_with_timestamp("Invalid operation choice received.");
+                snprintf(buffer, BUF_SIZE, "Invalid operation choice.");
                 sendto(sockfd, buffer, strlen(buffer), 0, (struct sockaddr *)&client_addr, addr_len);
                 continue;
         }
 
         // Send result
         snprintf(buffer, BUF_SIZE, "Result: %.2lf", result);
+        log_with_timestamp("Sending result to client.");
         sendto(sockfd, buffer, strlen(buffer), 0, (struct sockaddr *)&client_addr, addr_len);
     }
 
+    log_with_timestamp("UDP Server shutting down.");
     close(sockfd);
     return 0;
 }

--- a/json_rpc/DISTRIBUTED_SETUP.md
+++ b/json_rpc/DISTRIBUTED_SETUP.md
@@ -1,0 +1,246 @@
+# Distributed Calculator Setup Guide
+
+## 1. Overview
+
+This document describes the setup and operation of a distributed calculator system. The system consists of the following main components:
+
+-   **JSON-RPC Gateway (`json_rpc/server`):** The central entry point for clients. It receives JSON-RPC requests, routes them to appropriate backend calculation servers, and returns responses to the client. It also manages the lifecycle of configured backend processes and listens for their registrations.
+-   **Backend Calculation Servers (e.g., `concurrent_tcp_async/server`, `iterative_udp/server`):** These are individual server processes that perform the actual calculations (add, subtract, multiply, divide). They can be TCP or UDP based. They register with the gateway upon startup.
+-   **JSON-RPC Client (`json_rpc/client`):** A command-line utility to send JSON-RPC requests to the gateway.
+
+The communication flow is as follows:
+1.  The gateway starts and launches backend server processes as defined in `backends.conf`.
+2.  Backend servers, upon starting, send a UDP registration message to the gateway, announcing their type (TCP/UDP), host, port, name, and supported operations.
+3.  The client sends a JSON-RPC request (e.g., for "add") to the gateway.
+4.  The gateway selects an appropriate registered backend server that supports the requested operation using a round-robin strategy.
+5.  The gateway translates the JSON-RPC request into the simple protocol understood by the backend (e.g., "1 <num1> <num2>" for addition).
+6.  The gateway forwards this translated request to the chosen backend server.
+7.  The backend server processes the request and sends a simple response (e.g., "Result: <value>" or "Error: <message>").
+8.  The gateway receives this response, translates it back into a JSON-RPC response format, and sends it to the client.
+
+## 2. Prerequisites
+
+Before compiling and running the system, ensure you have the following installed:
+
+-   **`gcc` (GNU Compiler Collection):** For compiling the C source code.
+-   **`make`:** For using the provided Makefiles to simplify compilation.
+-   **`libjson-c-dev`:** The JSON-C library development files. This is specifically required for compiling `json_rpc/client.c` which uses this library for JSON parsing.
+    -   On Debian/Ubuntu-based systems, you can install it using:
+        ```bash
+        sudo apt-get update
+        sudo apt-get install gcc make libjson-c-dev
+        ```
+
+## 3. Compilation
+
+Navigate to the root directory of the project structure.
+
+### Compiling the Gateway Server
+
+```bash
+cd json_rpc
+make server
+# This will create an executable: json_rpc/server
+cd ..
+```
+
+### Compiling Example Backend Servers
+
+**Concurrent TCP Async Server:**
+
+```bash
+cd concurrent_tcp_async
+make server
+# This will create an executable: concurrent_tcp_async/server
+cd ..
+```
+
+**Iterative UDP Server:**
+
+```bash
+cd iterative_udp
+make server
+# This will create an executable: iterative_udp/server
+cd ..
+```
+
+Ensure the Makefiles in these directories are correctly set up to produce the executables with the specified names.
+
+### Compiling the JSON-RPC Client
+
+```bash
+cd json_rpc
+make client
+# This will create an executable: json_rpc/client
+# This step requires libjson-c-dev to be installed.
+cd ..
+```
+
+## 4. Configuration (`json_rpc/backends.conf`)
+
+The `json_rpc/backends.conf` file tells the gateway server which backend processes to launch and manage at startup.
+
+-   **Purpose:** Defines a list of backend calculation servers that the gateway should start and monitor.
+-   **Location:** Must be in the `json_rpc/` directory, named `backends.conf`.
+-   **Format:** Each line defines one backend server with the following space-separated fields:
+    `<executable_path> <server_name> <listen_host> <listen_port> <server_type>`
+
+    -   `executable_path`: Relative or absolute path to the backend server's executable.
+        -   *Note on relative paths:* Relative paths are typically interpreted relative to the directory where the `json_rpc/server` (gateway) is executed. It's generally recommended to use paths relative to the project root or ensure the gateway is run from the project root. For example, `../concurrent_tcp_async/server`.
+    -   `server_name`: A unique name for this backend instance (e.g., `tcp_async_1`). This name is used in logs and for service registration.
+    -   `listen_host`: The IP address the backend server should listen on (e.g., `127.0.0.1`). This is also the host that the backend will report during its registration to the gateway.
+    -   `listen_port`: The port number the backend server should listen on (e.g., `9001`). This is also the port the backend will report during registration.
+    -   `server_type`: The protocol type of the backend server. Must be either `TCP` or `UDP`.
+
+-   **Example `backends.conf` content:**
+
+    ```
+    ../concurrent_tcp_async/server tcp_async_1 127.0.0.1 9001 TCP
+    ../iterative_udp/server udp_iter_1 127.0.0.1 9002 UDP
+    ../concurrent_tcp_async/server tcp_async_2 127.0.0.1 9003 TCP
+    ../iterative_udp/server udp_iter_2 127.0.0.1 9004 UDP
+    ```
+
+    -   In this example:
+        -   The first line launches `concurrent_tcp_async/server`, names it `tcp_async_1`, configures it to listen on `127.0.0.1:9001`, and identifies it as a `TCP` server.
+        -   The second line launches `iterative_udp/server`, names it `udp_iter_1`, configures it for `127.0.0.1:9002` as a `UDP` server.
+
+-   **Important:** The backend servers themselves must be compiled and present at the specified `executable_path` for the gateway to launch them successfully.
+
+## 5. Running the System
+
+Ensure all components (gateway, backends, client) are compiled as described in Section 3.
+
+### Step 1: Configure `backends.conf`
+
+-   Open `json_rpc/backends.conf` in a text editor.
+-   Verify that the `executable_path` for each backend server correctly points to its compiled executable relative to where you will run the `json_rpc/server`.
+-   Ensure `server_name` is unique for each entry.
+-   Choose appropriate `listen_host` and `listen_port` for each backend. These ports must be available.
+
+### Step 2: Run the JSON-RPC Gateway Server
+
+It's generally best to run the gateway from the project's root directory to ensure relative paths in `backends.conf` work as expected.
+
+```bash
+./json_rpc/server
+```
+
+**What to look for in the gateway logs:**
+
+-   **Gateway Listening Port:**
+    `[YYYY-MM-DD HH:MM:SS] [INFO] JSON-RPC Server listening on port 8080` (or your `DEFAULT_PORT`)
+-   **Discovery Port Listening:**
+    `[YYYY-MM-DD HH:MM:SS] [INFO] Discovery UDP socket listening on 0.0.0.0:8081` (or your `GATEWAY_DISCOVERY_HOST`:`GATEWAY_DISCOVERY_PORT`)
+-   **Backend Launch Attempts (from `backends.conf`):**
+    `[YYYY-MM-DD HH:MM:SS] [INFO] Attempting to launch backend: ../concurrent_tcp_async/server (Name: tcp_async_1, Host: 127.0.0.1, Port: 9001, Type: TCP)`
+    `[YYYY-MM-DD HH:MM:SS] [INFO] Backend tcp_async_1 launched successfully with PID: <pid>`
+-   **Backend Registration Messages (from launched or independently started backends):**
+    `[YYYY-MM-DD HH:MM:SS] [INFO] Received registration message from 127.0.0.1:<backend_udp_port> : type=TCP;host=127.0.0.1;port=9001;name=tcp_async_1;ops=add,subtract,multiply,divide`
+    `[YYYY-MM-DD HH:MM:SS] [INFO] Registered new backend: tcp_async_1 (Type: TCP, Host: 127.0.0.1, Port: 9001, Ops: add,subtract,multiply,divide)`
+    or
+    `[YYYY-MM-DD HH:MM:SS] [INFO] Updated registration for backend: tcp_async_1 (...)`
+
+If `backends.conf` is empty or all launch attempts fail, you might see:
+`[YYYY-MM-DD HH:MM:SS] [WARNING] CRITICAL SETUP: No backends were successfully launched from backends.conf...`
+
+### Step 3: Run the JSON-RPC Client
+
+Open a new terminal. The client sends a JSON-RPC request to the gateway.
+
+**Example Client Usage:**
+
+To request an "add" operation with parameters 10 and 5:
+
+```bash
+./json_rpc/client '{"jsonrpc": "2.0", "method": "add", "params": [10.0, 5.0], "id": 1}'
+```
+
+To request a "divide" operation:
+
+```bash
+./json_rpc/client '{"jsonrpc": "2.0", "method": "divide", "params": [100.0, 10.0], "id": 2}'
+```
+
+**Observing Gateway Logs for Routing:**
+
+When the client sends a request, check the gateway's terminal output. You should see logs indicating how the request is processed:
+
+-   `[YYYY-MM-DD HH:MM:SS] [DEBUG] Received JSON-RPC request: {"jsonrpc": "2.0", ...}`
+-   `[YYYY-MM-DD HH:MM:SS] [INFO] Selected backend <backend_name> for operation <method_name> via round-robin...`
+-   `[YYYY-MM-DD HH:MM:SS] [INFO] Routing request for method '<method_name>' (id: <id>) to backend: <backend_name> (<host>:<port>)`
+-   `[YYYY-MM-DD HH:MM:SS] [INFO] Attempting <TCP/UDP> communication with <backend_name> ... Payload: "<op_code> <param1> <param2>"`
+-   `[YYYY-MM-DD HH:MM:SS] [INFO] <TCP/UDP> received from backend <backend_name>: Result: <value>`
+-   `[YYYY-MM-DD HH:MM:SS] [DEBUG] Sending JSON-RPC response (id: <id>): {"jsonrpc": "2.0", "result": <value>, "id": <id>}`
+
+The client will print the JSON-RPC response it receives from the gateway.
+
+## 6. Key Mechanisms Explained
+
+-   **Process Management:**
+    The gateway server (`json_rpc/server`) is responsible for launching and monitoring backend calculation servers as defined in `json_rpc/backends.conf`. If a managed backend process exits unexpectedly, the gateway will attempt to relaunch it. This provides a basic level of fault tolerance.
+
+-   **Service Registration:**
+    -   When a backend server (either launched by the gateway or started independently) starts up, it sends a UDP registration message to the gateway's discovery port (`GATEWAY_DISCOVERY_PORT`, typically 8081).
+    -   **Message Format:** The registration message is a plain text string with key-value pairs separated by semicolons (`;`), and keys and values separated by equals signs (`=`).
+        Example: `type=TCP;host=127.0.0.1;port=9001;name=tcp_async_1;ops=add,subtract,multiply,divide`
+        -   `type`: `TCP` or `UDP`.
+        -   `host`: IP address of the backend.
+        -   `port`: Port number of the backend.
+        -   `name`: Unique name of the backend instance.
+        -   `ops`: Comma-separated list of operations supported (e.g., `add,subtract,multiply,divide`).
+    -   The gateway maintains a list of these registered backends, updating their `last_seen` time and `is_active` status. (Note: The current implementation always sets `is_active=1` on registration/update; a timeout mechanism to mark inactive backends is a potential future enhancement).
+
+-   **Dynamic Routing:**
+    -   When the gateway receives a JSON-RPC request, it determines the `method` (e.g., "add").
+    -   It then consults its list of currently registered and active backend servers.
+    -   It filters this list to find backends that support the requested operation (based on the `ops` field in their registration).
+    -   If multiple suitable backends are found, the gateway uses a simple **round-robin** strategy to select one. This helps distribute the load among available backends.
+    -   If no suitable backend is found, an error is returned to the client.
+
+-   **Protocol Translation:**
+    -   **Client to Gateway:** The client communicates with the gateway using JSON-RPC 2.0 over TCP.
+    -   **Gateway to Backend:** The backend servers expect a simpler protocol:
+        -   A plain text string: `<op_code> <param1> <param2>`
+        -   `op_code`: An integer (1 for add, 2 for subtract, 3 for multiply, 4 for divide).
+        -   `param1`, `param2`: Floating-point numbers.
+    -   The gateway translates the incoming JSON-RPC `method` and `params` into this simpler format before forwarding to the backend.
+    -   **Backend to Gateway:** Backends respond with:
+        -   `Result: <value>` for success.
+        -   `Error: <error_message>` for failure.
+    -   The gateway parses this simple text response and translates it back into a valid JSON-RPC response (either a `result` or an `error` object) for the client.
+
+## 7. Troubleshooting Tips
+
+-   **Gateway Server Logs (`json_rpc/server` output):** This is the most important place to look.
+    -   Check for successful binding to the JSON-RPC port and the UDP discovery port.
+    -   Verify that backends listed in `backends.conf` are being launched (or if there are errors during launch like "execv failed").
+    -   Look for "Received registration message" and "Registered new backend" (or "Updated registration") messages. If these are missing, your backends are not successfully registering.
+    -   When a client request comes in, observe the "Selected backend" and "Routing request" messages to see where the gateway is attempting to send the work.
+    -   Check for communication errors with backends (e.g., "Failed to connect", "Timeout receiving data").
+
+-   **Backend Server Logs (e.g., `concurrent_tcp_async/server` output):**
+    -   Ensure the backend server starts and binds to the host/port specified in `backends.conf`.
+    -   Look for logs indicating it's attempting to register with the gateway (e.g., "Registration message sent to <gateway_host>:<gateway_port>").
+    -   Check for any errors if it receives a request from the gateway.
+
+-   **Verify `backends.conf` Paths:**
+    -   Double-check that the `executable_path` for each backend in `json_rpc/backends.conf` is correct *relative to the directory where you are running the `json_rpc/server` executable*.
+    -   If using relative paths like `../concurrent_tcp_async/server`, it's usually best to run `json_rpc/server` from the project's root directory.
+
+-   **Check if Backend Processes Are Running:**
+    -   After starting `json_rpc/server`, use commands like `ps aux | grep server` (or more specific names) to see if the backend processes (e.g., `concurrent_tcp_async/server`) were actually launched and are still running.
+    -   If they are not running, check the gateway logs for `fork` or `execv` errors related to that backend.
+
+-   **Firewall Issues:**
+    -   Ensure no firewalls are blocking TCP connections to the gateway's JSON-RPC port (default 8080) from the client.
+    -   Ensure no firewalls are blocking UDP packets to the gateway's discovery port (default 8081) from the backend servers.
+    -   Ensure no firewalls are blocking TCP/UDP connections from the gateway machine to the backend server machines on their respective ports.
+
+-   **Client Errors:**
+    -   If the client gets an error, correlate it with the gateway logs. The gateway might provide more details about why the request failed (e.g., "Method not supported", "Error communicating with backend").
+
+-   **Supported Operations:**
+    -   Ensure the `ops=` field in the backend's registration message (and thus how the backend is programmed) correctly lists all operations it supports. The gateway uses this for routing. The standard backends support `add,subtract,multiply,divide`.
+
+This guide should help in setting up, running, and troubleshooting the distributed calculator system.

--- a/json_rpc/backends.conf
+++ b/json_rpc/backends.conf
@@ -1,0 +1,4 @@
+../concurrent_tcp_async/server tcp_async_1 127.0.0.1 9001 TCP
+../iterative_udp/server udp_iter_1 127.0.0.1 9002 UDP
+../concurrent_tcp_async/server tcp_async_2 127.0.0.1 9003 TCP
+../iterative_udp/server udp_iter_2 127.0.0.1 9004 UDP

--- a/json_rpc/server.c
+++ b/json_rpc/server.c
@@ -4,257 +4,1011 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <unistd.h>
+#include <sys/types.h> // Added for pid_t
+#include <sys/wait.h>  // Added for waitpid
+#include <errno.h>     // Added for errno
+#include <getopt.h>    // Added for getopt_long
+#include <time.h>      // For logging timestamp
+#include <arpa/inet.h> // Added for inet_ntoa and other network functions
+#include <sys/select.h> // Added for select()
+#include <fcntl.h>     // Added for fcntl O_NONBLOCK
 
 #define DEFAULT_PORT 8080
 #define BUFFER_SIZE 1024
+#define MAX_BACKENDS 10 // Maximum number of backend processes to manage
+#define MAX_REGISTERED_BACKENDS_CONFIG 20 // Max backends registered via discovery
+#define GATEWAY_DISCOVERY_HOST "0.0.0.0" // Listen on all interfaces for discovery
+#define GATEWAY_DISCOVERY_PORT 8081
 
-// Calculator functions
+// Structure to hold information about a running backend process
+typedef struct {
+    pid_t pid;
+    char name[100];
+    char exec_path[256];
+    char listen_host[100];
+    char listen_port_str[10]; // Store as string
+    char server_type[50];
+    int is_running; // Flag to indicate if it's supposed to be running
+} ManagedBackend;
+
+ManagedBackend managed_backends[MAX_BACKENDS];
+int num_managed_backends = 0;
+
+// Structure for discovered backends
+typedef struct {
+    char type[10]; // "TCP" or "UDP"
+    char host[256];
+    int port;
+    char name[100];
+    char operations[512]; // Comma-separated list like "add,subtract,multiply"
+    time_t last_seen;
+    int is_active; // 1 for active, 0 for inactive
+} RegisteredBackend;
+
+RegisteredBackend registered_backends[MAX_REGISTERED_BACKENDS_CONFIG];
+int num_registered_backends = 0;
+int discovery_fd; // File descriptor for the UDP discovery socket
+static unsigned int round_robin_counter = 0; // For round-robin backend selection
+
+
+// Function for logging with timestamp
+void log_with_timestamp(const char *level, const char *message) {
+    time_t now = time(NULL);
+    char buf[sizeof("YYYY-MM-DD HH:MM:SS")];
+    strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", localtime(&now));
+    // Output to stdout for now, could be stderr or a file
+    printf("[%s] [%s] %s\n", buf, level, message);
+}
+
+
+// Maps JSON-RPC method name to backend operation code
+int get_backend_op_code(const char* json_rpc_method) {
+    if (strcmp(json_rpc_method, "add") == 0) return 1;
+    if (strcmp(json_rpc_method, "subtract") == 0) return 2;
+    if (strcmp(json_rpc_method, "multiply") == 0) return 3;
+    if (strcmp(json_rpc_method, "divide") == 0) return 4;
+
+    char log_buf[100];
+    snprintf(log_buf, sizeof(log_buf), "Unknown JSON-RPC method for op code translation: %s", json_rpc_method);
+    log_with_timestamp("WARNING", log_buf);
+    return 0; // Unknown or unsupported method
+}
+
+// Communicate with a TCP backend
+int communicate_with_tcp_backend(const RegisteredBackend* backend, const char* request_payload, char* response_buf, size_t response_buf_size) {
+    char log_buf[512];
+    snprintf(log_buf, sizeof(log_buf), "Attempting TCP communication with %s at %s:%d. Payload: \"%s\"", backend->name, backend->host, backend->port, request_payload);
+    log_with_timestamp("INFO", log_buf);
+
+    int sock_fd;
+    struct sockaddr_in server_addr;
+
+    if ((sock_fd = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+        char err_buf[256];
+        snprintf(err_buf, sizeof(err_buf), "TCP socket creation for backend %s failed: %s", backend->name, strerror(errno));
+        perror("TCP socket creation failed for backend communication"); // System error
+        log_with_timestamp("ERROR", err_buf); // Application context
+        snprintf(response_buf, response_buf_size -1, "Gateway error: Failed to create TCP socket to backend %s.", backend->name);
+        response_buf[response_buf_size -1] = '\0';
+        return -1;
+    }
+
+    struct timeval tv;
+    tv.tv_sec = 5;
+    tv.tv_usec = 0;
+    if (setsockopt(sock_fd, SOL_SOCKET, SO_RCVTIMEO, (const char*)&tv, sizeof tv) < 0) {
+        char err_buf[256];
+        snprintf(err_buf, sizeof(err_buf), "setsockopt SO_RCVTIMEO for backend %s failed: %s", backend->name, strerror(errno));
+        perror("setsockopt SO_RCVTIMEO failed for TCP backend socket");
+        log_with_timestamp("ERROR", err_buf);
+        snprintf(response_buf, response_buf_size-1, "Gateway error: Failed to set TCP recv timeout for backend %s.", backend->name);
+        response_buf[response_buf_size -1] = '\0';
+        close(sock_fd);
+        return -1;
+    }
+    if (setsockopt(sock_fd, SOL_SOCKET, SO_SNDTIMEO, (const char*)&tv, sizeof tv) < 0) {
+        char err_buf[256];
+        snprintf(err_buf, sizeof(err_buf), "setsockopt SO_SNDTIMEO for backend %s failed: %s (non-critical)", backend->name, strerror(errno));
+        perror("setsockopt SO_SNDTIMEO failed for TCP backend socket (non-critical)");
+        log_with_timestamp("WARNING", err_buf);
+    }
+
+    memset(&server_addr, 0, sizeof(server_addr));
+    server_addr.sin_family = AF_INET;
+    server_addr.sin_port = htons(backend->port);
+    if (inet_pton(AF_INET, backend->host, &server_addr.sin_addr) <= 0) {
+        char err_buf[256];
+        snprintf(err_buf, sizeof(err_buf), "Invalid backend address %s for %s: %s", backend->host, backend->name, strerror(errno));
+        perror("Invalid address/ Address not supported for TCP backend");
+        log_with_timestamp("ERROR", err_buf);
+        snprintf(response_buf, response_buf_size-1, "Gateway error: Invalid backend address %s for %s.", backend->host, backend->name);
+        response_buf[response_buf_size -1] = '\0';
+        close(sock_fd);
+        return -1;
+    }
+
+    if (connect(sock_fd, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
+        char err_msg[256];
+        snprintf(err_msg, sizeof(err_msg), "TCP connect to backend %s (%s:%d) failed: %s", backend->name, backend->host, backend->port, strerror(errno));
+        log_with_timestamp("ERROR", err_msg);
+        snprintf(response_buf, response_buf_size-1, "Gateway error: Failed to connect to backend %s. Details: %s", backend->name, strerror(errno));
+        response_buf[response_buf_size -1] = '\0';
+        close(sock_fd);
+        return -1;
+    }
+    log_with_timestamp("INFO", "TCP connected to backend.");
+
+    if (send(sock_fd, request_payload, strlen(request_payload), 0) < 0) {
+        char err_msg[256];
+        snprintf(err_msg, sizeof(err_msg), "TCP send to backend %s (%s:%d) failed: %s", backend->name, backend->host, backend->port, strerror(errno));
+        log_with_timestamp("ERROR", err_msg);
+        snprintf(response_buf, response_buf_size-1, "Gateway error: Failed to send data to backend %s. Details: %s", backend->name, strerror(errno));
+        response_buf[response_buf_size -1] = '\0';
+        close(sock_fd);
+        return -1;
+    }
+    log_with_timestamp("INFO", "TCP data sent to backend.");
+
+    ssize_t bytes_received = recv(sock_fd, response_buf, response_buf_size - 1, 0);
+    if (bytes_received < 0) {
+        if (errno == EAGAIN || errno == EWOULDBLOCK) {
+            snprintf(log_buf, sizeof(log_buf), "TCP recv from backend %s timed out.", backend->name);
+            log_with_timestamp("ERROR", log_buf);
+            snprintf(response_buf, response_buf_size-1, "Gateway error: Timeout receiving data from backend %s.", backend->name);
+        } else {
+            char err_msg[256];
+            snprintf(err_msg, sizeof(err_msg), "TCP recv from backend %s (%s:%d) failed: %s", backend->name, backend->host, backend->port, strerror(errno));
+            log_with_timestamp("ERROR", err_msg);
+            snprintf(response_buf, response_buf_size-1, "Gateway error: Failed to receive data from backend %s. Details: %s", backend->name, strerror(errno));
+        }
+        response_buf[response_buf_size -1] = '\0';
+        close(sock_fd);
+        return -1;
+    }
+    response_buf[bytes_received] = '\0';
+    snprintf(log_buf, sizeof(log_buf), "TCP received from backend %s: %s", backend->name, response_buf);
+    log_with_timestamp("INFO", log_buf);
+
+    close(sock_fd);
+    return 0;
+}
+
+// Communicate with a UDP backend
+int communicate_with_udp_backend(const RegisteredBackend* backend, const char* request_payload, char* response_buf, size_t response_buf_size) {
+    char log_buf[512];
+    snprintf(log_buf, sizeof(log_buf), "Attempting UDP communication with %s at %s:%d. Payload: \"%s\"", backend->name, backend->host, backend->port, request_payload);
+    log_with_timestamp("INFO", log_buf);
+
+    int sock_fd;
+    struct sockaddr_in server_addr, from_addr;
+    socklen_t from_addr_len = sizeof(from_addr);
+
+    if ((sock_fd = socket(AF_INET, SOCK_DGRAM, 0)) < 0) {
+        char err_buf[256];
+        snprintf(err_buf, sizeof(err_buf), "UDP socket creation for backend %s failed: %s", backend->name, strerror(errno));
+        perror("UDP socket creation failed for backend communication");
+        log_with_timestamp("ERROR", err_buf);
+        snprintf(response_buf, response_buf_size-1, "Gateway error: Failed to create UDP socket for backend %s.", backend->name);
+        response_buf[response_buf_size -1] = '\0';
+        return -1;
+    }
+
+    struct timeval tv;
+    tv.tv_sec = 5;
+    tv.tv_usec = 0;
+    if (setsockopt(sock_fd, SOL_SOCKET, SO_RCVTIMEO, (const char*)&tv, sizeof tv) < 0) {
+        char err_buf[256];
+        snprintf(err_buf, sizeof(err_buf), "setsockopt SO_RCVTIMEO for UDP backend %s failed: %s", backend->name, strerror(errno));
+        perror("setsockopt SO_RCVTIMEO failed for UDP backend socket");
+        log_with_timestamp("ERROR", err_buf);
+        snprintf(response_buf, response_buf_size-1, "Gateway error: Failed to set UDP recv timeout for backend %s.", backend->name);
+        response_buf[response_buf_size -1] = '\0';
+        close(sock_fd);
+        return -1;
+    }
+
+    memset(&server_addr, 0, sizeof(server_addr));
+    server_addr.sin_family = AF_INET;
+    server_addr.sin_port = htons(backend->port);
+    if (inet_pton(AF_INET, backend->host, &server_addr.sin_addr) <= 0) {
+        char err_buf[256];
+        snprintf(err_buf, sizeof(err_buf), "Invalid backend address %s for %s: %s", backend->host, backend->name, strerror(errno));
+        perror("Invalid address/ Address not supported for UDP backend");
+        log_with_timestamp("ERROR", err_buf);
+        snprintf(response_buf, response_buf_size-1, "Gateway error: Invalid backend address %s for %s.", backend->host, backend->name);
+        response_buf[response_buf_size -1] = '\0';
+        close(sock_fd);
+        return -1;
+    }
+
+    if (sendto(sock_fd, request_payload, strlen(request_payload), 0, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
+        char err_msg[256];
+        snprintf(err_msg, sizeof(err_msg), "UDP sendto to backend %s (%s:%d) failed: %s", backend->name, backend->host, backend->port, strerror(errno));
+        log_with_timestamp("ERROR", err_msg);
+        snprintf(response_buf, response_buf_size-1, "Gateway error: Failed to send data to UDP backend %s. Details: %s", backend->name, strerror(errno));
+        response_buf[response_buf_size -1] = '\0';
+        close(sock_fd);
+        return -1;
+    }
+    log_with_timestamp("INFO", "UDP data sent to backend.");
+
+    ssize_t bytes_received = recvfrom(sock_fd, response_buf, response_buf_size - 1, 0, (struct sockaddr *)&from_addr, &from_addr_len);
+    if (bytes_received < 0) {
+         if (errno == EAGAIN || errno == EWOULDBLOCK) {
+            snprintf(log_buf, sizeof(log_buf), "UDP recvfrom backend %s timed out.", backend->name);
+            log_with_timestamp("ERROR", log_buf);
+            snprintf(response_buf, response_buf_size-1, "Gateway error: Timeout receiving data from UDP backend %s.", backend->name);
+        } else {
+            char err_msg[256];
+            snprintf(err_msg, sizeof(err_msg), "UDP recvfrom backend %s (%s:%d) failed: %s", backend->name, backend->host, backend->port, strerror(errno));
+            log_with_timestamp("ERROR", err_msg);
+            snprintf(response_buf, response_buf_size-1, "Gateway error: Failed to receive data from UDP backend %s. Details: %s", backend->name, strerror(errno));
+        }
+        response_buf[response_buf_size -1] = '\0';
+        close(sock_fd);
+        return -1;
+    }
+    response_buf[bytes_received] = '\0';
+    snprintf(log_buf, sizeof(log_buf), "UDP received from backend %s: %s", backend->name, response_buf);
+    log_with_timestamp("INFO", log_buf);
+
+    close(sock_fd);
+    return 0;
+}
+
+// Parses the simple "Result: value" or "Error: message" from backend
+int parse_backend_response(const char* backend_response_str, double* result_out, char* error_msg_out, size_t error_msg_out_size) {
+    if (!backend_response_str || !result_out || !error_msg_out) {
+        log_with_timestamp("CRITICAL", "NULL argument to parse_backend_response");
+        if(error_msg_out) snprintf(error_msg_out, error_msg_out_size-1, "Gateway internal error: parsing backend response with NULL params.");
+        if(error_msg_out && error_msg_out_size > 0) error_msg_out[error_msg_out_size-1] = '\0';
+        return -1;
+    }
+
+    char log_buf[1024];
+    snprintf(log_buf, sizeof(log_buf)-1, "Parsing backend response: \"%s\"", backend_response_str);
+    log_with_timestamp("DEBUG", log_buf);
+
+    if (strncmp(backend_response_str, "Result: ", 8) == 0) {
+        if (sscanf(backend_response_str + 8, "%lf", result_out) == 1) {
+            snprintf(log_buf, sizeof(log_buf)-1, "Parsed result from backend: %f", *result_out);
+            log_with_timestamp("DEBUG", log_buf);
+            return 0;
+        } else {
+            snprintf(error_msg_out, error_msg_out_size-1, "Malformed result from backend: %s", backend_response_str);
+            error_msg_out[error_msg_out_size-1] = '\0';
+            log_with_timestamp("ERROR", error_msg_out);
+            return -1;
+        }
+    } else if (strncmp(backend_response_str, "Error: ", 7) == 0) {
+        strncpy(error_msg_out, backend_response_str + 7, error_msg_out_size - 1);
+        error_msg_out[error_msg_out_size - 1] = '\0';
+        snprintf(log_buf, sizeof(log_buf)-1, "Parsed error from backend: \"%s\"", error_msg_out);
+        log_with_timestamp("INFO", log_buf);
+        return 1;
+    }
+
+    snprintf(error_msg_out, error_msg_out_size-1, "Unknown response format from backend: %s", backend_response_str);
+    error_msg_out[error_msg_out_size-1] = '\0';
+    log_with_timestamp("ERROR", error_msg_out);
+    return -1;
+}
+
+int is_operation_supported(const RegisteredBackend* backend, const char* operation_name) {
+    if (!backend || !backend->is_active || !operation_name) {
+        return 0;
+    }
+    char ops_copy[sizeof(backend->operations)];
+    strncpy(ops_copy, backend->operations, sizeof(ops_copy) -1);
+    ops_copy[sizeof(ops_copy)-1] = '\0';
+
+    char *saveptr;
+    char *token = strtok_r(ops_copy, ",", &saveptr);
+    while (token != NULL) {
+        if (strcmp(token, operation_name) == 0) {
+            return 1;
+        }
+        token = strtok_r(NULL, ",", &saveptr);
+    }
+    return 0;
+}
+
+RegisteredBackend* select_backend(const char* operation_name, char* chosen_backend_name_out, size_t chosen_backend_name_out_size) {
+    char log_buf[512];
+    if (!operation_name || !chosen_backend_name_out) return NULL;
+
+    RegisteredBackend* candidates[MAX_REGISTERED_BACKENDS_CONFIG];
+    int num_candidates = 0;
+
+    for (int i = 0; i < num_registered_backends; ++i) {
+        if (is_operation_supported(&registered_backends[i], operation_name)) {
+            if (num_candidates < MAX_REGISTERED_BACKENDS_CONFIG) {
+                 candidates[num_candidates++] = &registered_backends[i];
+            } else {
+                log_with_timestamp("WARNING", "Exceeded candidate array capacity in select_backend. This shouldn't happen.");
+                break;
+            }
+        }
+    }
+
+    if (num_candidates == 0) {
+        snprintf(log_buf, sizeof(log_buf), "No active backend found supporting operation: %s", operation_name);
+        log_with_timestamp("WARNING", log_buf);
+        strncpy(chosen_backend_name_out, "N/A (No suitable backend)", chosen_backend_name_out_size -1);
+        chosen_backend_name_out[chosen_backend_name_out_size-1] = '\0';
+        return NULL;
+    }
+
+    RegisteredBackend* selected = candidates[round_robin_counter % num_candidates];
+    round_robin_counter++;
+
+    strncpy(chosen_backend_name_out, selected->name, chosen_backend_name_out_size -1);
+    chosen_backend_name_out[chosen_backend_name_out_size-1] = '\0';
+
+    snprintf(log_buf, sizeof(log_buf), "Selected backend %s for operation %s via round-robin from %d candidates.", selected->name, operation_name, num_candidates);
+    log_with_timestamp("INFO", log_buf);
+
+    return selected;
+}
+
+void setup_discovery_socket() {
+    char log_buf[256];
+    struct sockaddr_in discovery_addr;
+
+    discovery_fd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (discovery_fd < 0) {
+        perror("Discovery socket creation failed");
+        log_with_timestamp("ERROR", "Discovery UDP socket creation failed.");
+        exit(EXIT_FAILURE);
+    }
+
+    int flags = fcntl(discovery_fd, F_GETFL, 0);
+    if (flags == -1) {
+        perror("fcntl F_GETFL failed for discovery_fd");
+        log_with_timestamp("ERROR", "fcntl F_GETFL failed for discovery_fd.");
+        close(discovery_fd);
+        exit(EXIT_FAILURE);
+    }
+    if (fcntl(discovery_fd, F_SETFL, flags | O_NONBLOCK) == -1) {
+        perror("fcntl F_SETFL O_NONBLOCK failed for discovery_fd");
+        log_with_timestamp("ERROR", "fcntl F_SETFL O_NONBLOCK failed for discovery_fd.");
+        close(discovery_fd);
+        exit(EXIT_FAILURE);
+    }
+
+    int optval = 1;
+    setsockopt(discovery_fd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
+
+    memset(&discovery_addr, 0, sizeof(discovery_addr));
+    discovery_addr.sin_family = AF_INET;
+    if (strcmp(GATEWAY_DISCOVERY_HOST, "0.0.0.0") == 0) {
+        discovery_addr.sin_addr.s_addr = INADDR_ANY;
+    } else {
+        if (inet_pton(AF_INET, GATEWAY_DISCOVERY_HOST, &discovery_addr.sin_addr) <= 0) {
+            perror("Invalid GATEWAY_DISCOVERY_HOST address");
+            snprintf(log_buf, sizeof(log_buf), "Invalid GATEWAY_DISCOVERY_HOST address: %s", GATEWAY_DISCOVERY_HOST);
+            log_with_timestamp("ERROR", log_buf);
+            close(discovery_fd);
+            exit(EXIT_FAILURE);
+        }
+    }
+    discovery_addr.sin_port = htons(GATEWAY_DISCOVERY_PORT);
+
+    if (bind(discovery_fd, (struct sockaddr *)&discovery_addr, sizeof(discovery_addr)) < 0) {
+        perror("Discovery socket bind failed");
+        snprintf(log_buf, sizeof(log_buf), "Discovery UDP socket bind failed on %s:%d - %s.", GATEWAY_DISCOVERY_HOST, GATEWAY_DISCOVERY_PORT, strerror(errno));
+        log_with_timestamp("ERROR", log_buf);
+        close(discovery_fd);
+        exit(EXIT_FAILURE);
+    }
+
+    snprintf(log_buf, sizeof(log_buf), "Discovery UDP socket listening on %s:%d", GATEWAY_DISCOVERY_HOST, GATEWAY_DISCOVERY_PORT);
+    log_with_timestamp("INFO", log_buf);
+}
+
+int parse_registration_message(const char* msg, RegisteredBackend* backend_info) {
+    if (!msg || !backend_info) return -1;
+    char log_buf[1024];
+    snprintf(log_buf, sizeof(log_buf), "Parsing registration message: %s", msg);
+    log_with_timestamp("DEBUG", log_buf);
+
+    memset(backend_info, 0, sizeof(RegisteredBackend));
+
+    char msg_copy[1024];
+    strncpy(msg_copy, msg, sizeof(msg_copy) -1);
+    msg_copy[sizeof(msg_copy)-1] = '\0';
+
+    char *saveptr1, *saveptr2;
+    char *token = strtok_r(msg_copy, ";", &saveptr1);
+    int found_fields = 0;
+
+    while (token != NULL) {
+        char *key = strtok_r(token, "=", &saveptr2);
+        char *value = strtok_r(NULL, "=", &saveptr2);
+
+        if (key && value) {
+            if (strcmp(key, "type") == 0) {
+                strncpy(backend_info->type, value, sizeof(backend_info->type) - 1);
+                backend_info->type[sizeof(backend_info->type) - 1] = '\0';
+                found_fields++;
+            } else if (strcmp(key, "host") == 0) {
+                strncpy(backend_info->host, value, sizeof(backend_info->host) - 1);
+                backend_info->host[sizeof(backend_info->host) - 1] = '\0';
+                found_fields++;
+            } else if (strcmp(key, "port") == 0) {
+                backend_info->port = atoi(value);
+                if (backend_info->port == 0 && strcmp(value, "0") != 0) {
+                    snprintf(log_buf, sizeof(log_buf), "Invalid port value in registration: %s for key %s", value, key);
+                    log_with_timestamp("ERROR", log_buf);
+                    return -1;
+                }
+                found_fields++;
+            } else if (strcmp(key, "name") == 0) {
+                strncpy(backend_info->name, value, sizeof(backend_info->name) - 1);
+                backend_info->name[sizeof(backend_info->name) - 1] = '\0';
+                found_fields++;
+            } else if (strcmp(key, "ops") == 0) {
+                strncpy(backend_info->operations, value, sizeof(backend_info->operations) - 1);
+                backend_info->operations[sizeof(backend_info->operations) - 1] = '\0';
+                found_fields++;
+            }
+        }
+        token = strtok_r(NULL, ";", &saveptr1);
+    }
+
+    if (found_fields < 5) {
+        snprintf(log_buf, sizeof(log_buf), "Incomplete registration message. Found %d fields. Original: %s", found_fields, msg);
+        log_with_timestamp("ERROR", log_buf);
+        return -1;
+    }
+
+    if(strlen(backend_info->name) == 0){
+        log_with_timestamp("ERROR", "Backend name is empty after parsing.");
+        return -1;
+    }
+
+    backend_info->last_seen = time(NULL);
+    backend_info->is_active = 1;
+    return 0;
+}
+
+void process_registration_message(const char* buffer, ssize_t len) {
+    char log_buf[1024];
+    char safe_buffer[1024];
+    if (len >= (ssize_t)sizeof(safe_buffer)) {
+        log_with_timestamp("ERROR", "Received registration message too long to process.");
+        return;
+    }
+    memcpy(safe_buffer, buffer, len);
+    safe_buffer[len] = '\0';
+
+    RegisteredBackend backend_info;
+    if (parse_registration_message(safe_buffer, &backend_info) == 0) {
+        int found_idx = -1;
+        for (int i = 0; i < num_registered_backends; ++i) {
+            if (strcmp(registered_backends[i].name, backend_info.name) == 0) {
+                found_idx = i;
+                break;
+            }
+        }
+
+        if (found_idx != -1) {
+            registered_backends[found_idx] = backend_info;
+            snprintf(log_buf, sizeof(log_buf), "Updated registration for backend: %s (Type: %s, Host: %s, Port: %d, Ops: %s)",
+                     backend_info.name, backend_info.type, backend_info.host, backend_info.port, backend_info.operations);
+            log_with_timestamp("INFO", log_buf);
+        } else {
+            if (num_registered_backends < MAX_REGISTERED_BACKENDS_CONFIG) {
+                registered_backends[num_registered_backends++] = backend_info;
+                snprintf(log_buf, sizeof(log_buf), "Registered new backend: %s (Type: %s, Host: %s, Port: %d, Ops: %s)",
+                         backend_info.name, backend_info.type, backend_info.host, backend_info.port, backend_info.operations);
+                log_with_timestamp("INFO", log_buf);
+            } else {
+                snprintf(log_buf, sizeof(log_buf), "Cannot register backend %s: list full (max %d).", backend_info.name, MAX_REGISTERED_BACKENDS_CONFIG);
+                log_with_timestamp("WARNING", log_buf);
+            }
+        }
+    } else {
+        snprintf(log_buf, sizeof(log_buf), "Failed to parse registration message: %s", safe_buffer);
+        log_with_timestamp("ERROR", log_buf);
+    }
+}
+
 double add(double a, double b);
 double subtract(double a, double b);
 double multiply(double a, double b);
 double divide(double a, double b);
 
-// JSON parsing and building functions
 int parse_json_rpc_request(const char *json_str, char *method, double *params, int *id);
 void build_json_rpc_response(char *response_str, int id, double result, const char *error_message);
 
+pid_t launch_backend(const char* exec_path, const char* server_name, const char* listen_host, const char* listen_port_str, const char* server_type) {
+    char log_buffer[512];
+    snprintf(log_buffer, sizeof(log_buffer), "Attempting to launch backend: %s (Name: %s, Host: %s, Port: %s, Type: %s)",
+             exec_path, server_name, listen_host, listen_port_str, server_type);
+    log_with_timestamp("INFO", log_buffer);
+
+    pid_t pid = fork();
+    if (pid == -1) {
+        perror("fork failed");
+        snprintf(log_buffer, sizeof(log_buffer), "Failed to fork for backend %s: %s", server_name, strerror(errno));
+        log_with_timestamp("ERROR", log_buffer);
+        return 0;
+    } else if (pid == 0) {
+        char gateway_port_str[10];
+        snprintf(gateway_port_str, sizeof(gateway_port_str), "%d", GATEWAY_DISCOVERY_PORT);
+
+        char *argv[] = {
+            (char*)exec_path,
+            "--my-host", (char*)listen_host,
+            "--my-port", (char*)listen_port_str,
+            "--server-name", (char*)server_name,
+            "--gateway-host", GATEWAY_DISCOVERY_HOST, // This should be the routable IP of the gateway if backends are on different machines
+            "--gateway-port", gateway_port_str,
+            NULL
+        };
+
+        snprintf(log_buffer, sizeof(log_buffer), "Child process for %s executing: %s --my-host %s --my-port %s --server-name %s --gateway-host %s --gateway-port %s",
+            server_name, exec_path, listen_host, listen_port_str, server_name, GATEWAY_DISCOVERY_HOST, gateway_port_str);
+        log_with_timestamp("DEBUG", log_buffer);
+
+        execv(exec_path, argv);
+        perror("execv failed");
+        snprintf(log_buffer, sizeof(log_buffer), "execv failed for %s: %s", exec_path, strerror(errno));
+        log_with_timestamp("ERROR", log_buffer);
+        exit(EXIT_FAILURE);
+    } else {
+        snprintf(log_buffer, sizeof(log_buffer), "Backend %s launched successfully with PID: %d", server_name, pid);
+        log_with_timestamp("INFO", log_buffer);
+        return pid;
+    }
+}
+
+void load_and_launch_backends(const char* config_path) {
+    char log_buffer[512];
+    snprintf(log_buffer, sizeof(log_buffer), "Loading backends configuration from: %s", config_path);
+    log_with_timestamp("INFO", log_buffer);
+
+    FILE *file = fopen(config_path, "r");
+    if (!file) {
+        perror("fopen config_path failed");
+        snprintf(log_buffer, sizeof(log_buffer), "Failed to open backend config file %s: %s. No managed backends will be launched.", config_path, strerror(errno));
+        log_with_timestamp("ERROR", log_buffer);
+        return;
+    }
+
+    char line[512];
+    while (fgets(line, sizeof(line), file)) {
+        if (num_managed_backends >= MAX_BACKENDS) {
+            log_with_timestamp("WARNING", "Maximum number of managed backends reached. Skipping remaining entries in backends.conf.");
+            break;
+        }
+        line[strcspn(line, "\n")] = 0;
+        if (strlen(line) == 0 || line[0] == '#') continue; // Skip empty or comment lines
+
+
+        char exec_path[256], server_name[100], listen_host[100], listen_port_str[10], server_type[50];
+
+        if (sscanf(line, "%255s %99s %99s %9s %49s", exec_path, server_name, listen_host, listen_port_str, server_type) == 5) {
+            pid_t pid = launch_backend(exec_path, server_name, listen_host, listen_port_str, server_type);
+            if (pid > 0) {
+                ManagedBackend *backend = &managed_backends[num_managed_backends++];
+                backend->pid = pid;
+                strncpy(backend->name, server_name, sizeof(backend->name) - 1);
+                backend->name[sizeof(backend->name) - 1] = '\0';
+                strncpy(backend->exec_path, exec_path, sizeof(backend->exec_path) -1);
+                backend->exec_path[sizeof(backend->exec_path) -1] = '\0';
+                strncpy(backend->listen_host, listen_host, sizeof(backend->listen_host) -1);
+                backend->listen_host[sizeof(backend->listen_host) -1] = '\0';
+                strncpy(backend->listen_port_str, listen_port_str, sizeof(backend->listen_port_str) -1);
+                backend->listen_port_str[sizeof(backend->listen_port_str) -1] = '\0';
+                strncpy(backend->server_type, server_type, sizeof(backend->server_type) -1);
+                backend->server_type[sizeof(backend->server_type) -1] = '\0';
+                backend->is_running = 1;
+            } else {
+                snprintf(log_buffer, sizeof(log_buffer), "Failed to launch backend defined in line: %s", line);
+                log_with_timestamp("ERROR", log_buffer);
+            }
+        } else {
+            snprintf(log_buffer, sizeof(log_buffer), "Skipping malformed line in backend config: %s", line);
+            log_with_timestamp("WARNING", log_buffer);
+        }
+    }
+    fclose(file);
+    snprintf(log_buffer, sizeof(log_buffer), "Finished loading backends. Total managed backends launched: %d", num_managed_backends);
+    log_with_timestamp("INFO", log_buffer);
+}
+
+void check_managed_backends() {
+    char log_buffer[256];
+    for (int i = 0; i < num_managed_backends; ++i) {
+        if (managed_backends[i].pid > 0 && managed_backends[i].is_running) {
+            int status;
+            pid_t result = waitpid(managed_backends[i].pid, &status, WNOHANG);
+            if (result == managed_backends[i].pid) {
+                if (WIFEXITED(status)) {
+                    snprintf(log_buffer, sizeof(log_buffer), "Managed backend %s (PID: %d) exited with status %d.",
+                             managed_backends[i].name, managed_backends[i].pid, WEXITSTATUS(status));
+                    log_with_timestamp("INFO", log_buffer);
+                } else if (WIFSIGNALED(status)) {
+                    snprintf(log_buffer, sizeof(log_buffer), "Managed backend %s (PID: %d) killed by signal %d.",
+                             managed_backends[i].name, managed_backends[i].pid, WTERMSIG(status));
+                    log_with_timestamp("WARNING", log_buffer);
+                }
+                managed_backends[i].is_running = 0;
+                log_with_timestamp("INFO", "Attempting to relaunch backend...");
+                pid_t new_pid = launch_backend(managed_backends[i].exec_path, managed_backends[i].name, managed_backends[i].listen_host, managed_backends[i].listen_port_str, managed_backends[i].server_type);
+                if (new_pid > 0) {
+                    managed_backends[i].pid = new_pid;
+                    managed_backends[i].is_running = 1;
+                    snprintf(log_buffer, sizeof(log_buffer), "Backend %s re-launched with new PID: %d", managed_backends[i].name, new_pid);
+                    log_with_timestamp("INFO", log_buffer);
+                } else {
+                    snprintf(log_buffer, sizeof(log_buffer), "Failed to re-launch backend %s.", managed_backends[i].name);
+                    log_with_timestamp("ERROR", log_buffer);
+                }
+
+            } else if (result == -1) {
+                perror("waitpid error checking managed backend");
+                snprintf(log_buffer, sizeof(log_buffer), "Error checking status of managed backend %s (PID: %d): %s",
+                         managed_backends[i].name, managed_backends[i].pid, strerror(errno));
+                log_with_timestamp("ERROR", log_buffer);
+                managed_backends[i].is_running = 0;
+            }
+        }
+    }
+}
+
+
 int main() {
+    load_and_launch_backends("json_rpc/backends.conf");
+
+    if (num_managed_backends == 0) {
+        log_with_timestamp("WARNING", "CRITICAL SETUP: No backends were successfully launched from backends.conf. Gateway may not be able to process any backend requests that rely on these managed backends.");
+    }
+
+    setup_discovery_socket();
+
     int server_fd, client_fd;
     struct sockaddr_in address;
     int opt = 1;
     int addrlen = sizeof(address);
     char buffer[BUFFER_SIZE] = {0};
+    char log_buf[512];
 
-    // Create socket file descriptor
     if ((server_fd = socket(AF_INET, SOCK_STREAM, 0)) == 0) {
-        perror("socket failed");
+        perror("TCP socket failed");
+        log_with_timestamp("CRITICAL", "JSON-RPC TCP Socket creation failed. Exiting.");
         exit(EXIT_FAILURE);
     }
 
-    // Forcefully attaching socket to the port
     if (setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR | SO_REUSEPORT, &opt, sizeof(opt))) {
-        perror("setsockopt");
+        perror("setsockopt for TCP socket failed");
+        log_with_timestamp("CRITICAL", "setsockopt for JSON-RPC TCP socket failed. Exiting.");
         exit(EXIT_FAILURE);
     }
     address.sin_family = AF_INET;
     address.sin_addr.s_addr = INADDR_ANY;
     address.sin_port = htons(DEFAULT_PORT);
 
-    // Bind the socket to the network address and port
     if (bind(server_fd, (struct sockaddr *)&address, sizeof(address)) < 0) {
-        perror("bind failed");
+        perror("TCP bind failed");
+        snprintf(log_buf, sizeof(log_buf), "JSON-RPC TCP Bind failed for port %d: %s. Exiting.", DEFAULT_PORT, strerror(errno));
+        log_with_timestamp("CRITICAL", log_buf);
         exit(EXIT_FAILURE);
     }
 
-    // Listen for incoming connections
     if (listen(server_fd, 3) < 0) {
-        perror("listen");
+        perror("TCP listen failed");
+        log_with_timestamp("CRITICAL", "JSON-RPC TCP Listen failed. Exiting.");
         exit(EXIT_FAILURE);
     }
 
-    printf("Server listening on port %d\n", DEFAULT_PORT);
+    snprintf(log_buf, sizeof(log_buf), "JSON-RPC Server listening on port %d", DEFAULT_PORT);
+    log_with_timestamp("INFO", log_buf);
 
-    // Main server loop to accept and handle connections
     while(1) {
-        printf("Waiting for a new connection...\n");
-        // Accept an incoming connection
-        if ((client_fd = accept(server_fd, (struct sockaddr *)&address, (socklen_t*)&addrlen)) < 0) {
-            perror("accept failed"); // Clarified error message
+        check_managed_backends();
+
+        fd_set readfds;
+        FD_ZERO(&readfds);
+        FD_SET(server_fd, &readfds);
+        FD_SET(discovery_fd, &readfds);
+
+        int max_fd = (server_fd > discovery_fd ? server_fd : discovery_fd) + 1;
+
+        struct timeval timeout;
+        timeout.tv_sec = 1;
+        timeout.tv_usec = 0;
+
+        int activity = select(max_fd, &readfds, NULL, NULL, &timeout);
+
+        if (activity < 0 && errno != EINTR) {
+            char err_select_buf[100];
+            snprintf(err_select_buf, sizeof(err_select_buf), "Select error: %s. Continuing...", strerror(errno));
+            perror("select error"); // This will print the system error
+            log_with_timestamp("ERROR", err_select_buf); // Log our formatted error
             // Depending on the error, the server might continue or exit.
-            // For critical errors like EBADF, ENOTSOCK, EOPNOTSUPP, it might be better to exit.
-            // For now, we continue, which is suitable for errors like EINTR.
+            // For now, we continue, which is suitable for some transient errors.
+            // If select consistently fails, the server might become unresponsive.
+            // Consider adding a counter for consecutive select failures to exit eventually.
             continue;
         }
 
-        printf("Connection accepted from a client.\n");
-
-        // Read data from the client into the buffer
-        // BUFFER_SIZE - 1 to leave space for null terminator
-        memset(buffer, 0, BUFFER_SIZE); // Clear buffer before reading
-        ssize_t bytes_read = read(client_fd, buffer, BUFFER_SIZE - 1);
-
-        if (bytes_read < 0) {
-            perror("read from client failed");
-            close(client_fd);
-            continue; // Move to next connection
-        }
-
-        if (bytes_read == 0) { // Client closed connection
-            printf("Client disconnected gracefully (sent 0 bytes).\n");
-            close(client_fd);
+        if (activity == 0) {
             continue;
         }
 
-        buffer[bytes_read] = '\0'; // Null-terminate the received string to treat it as a C string
-        printf("Received request: %s\n", buffer);
+        if (FD_ISSET(discovery_fd, &readfds)) {
+            char reg_buffer[1024];
+            struct sockaddr_in backend_client_addr;
+            socklen_t backend_addr_len = sizeof(backend_client_addr);
 
-        // Variables to store parsed request components
-        char method[256]; // Buffer for method name
-        double params[2];   // Array for parameters (assuming two doubles for calculator functions)
-        int id = -1;        // Request ID, initialized to -1 (common for "unknown" ID)
+            ssize_t len = recvfrom(discovery_fd, reg_buffer, sizeof(reg_buffer) - 1, 0,
+                                   (struct sockaddr*)&backend_client_addr, &backend_addr_len);
 
-        // Attempt to parse the JSON-RPC request from the buffer
-        int parse_status = parse_json_rpc_request(buffer, method, params, &id);
+            if (len > 0) {
+                reg_buffer[len] = '\0';
+                char client_ip_str[INET_ADDRSTRLEN];
+                inet_ntop(AF_INET, &backend_client_addr.sin_addr, client_ip_str, INET_ADDRSTRLEN);
+                snprintf(log_buf, sizeof(log_buf), "Received registration message from %s:%d : %s",
+                         client_ip_str, ntohs(backend_client_addr.sin_port), reg_buffer);
+                log_with_timestamp("INFO", log_buf);
+                process_registration_message(reg_buffer, len);
+            } else if (len < 0 && (errno != EAGAIN && errno != EWOULDBLOCK)) {
+                char err_msg[256];
+                snprintf(err_msg, sizeof(err_msg), "Error receiving from discovery UDP socket: %s", strerror(errno));
+                perror("recvfrom discovery_fd error");
+                log_with_timestamp("ERROR", err_msg);
+            }
+        }
 
-        char response_str[BUFFER_SIZE]; // Buffer for the JSON response string
-        memset(response_str, 0, BUFFER_SIZE); // Clear response buffer
+        if (FD_ISSET(server_fd, &readfds)) {
+            log_with_timestamp("INFO", "Activity on JSON-RPC socket. Waiting for a new connection...");
+            if ((client_fd = accept(server_fd, (struct sockaddr *)&address, (socklen_t*)&addrlen)) < 0) {
+                char err_msg[256];
+                snprintf(err_msg, sizeof(err_msg), "Accept for JSON-RPC failed: %s", strerror(errno));
+                perror("accept for JSON-RPC failed");
+                log_with_timestamp("ERROR", err_msg);
+                continue;
+            }
+            log_with_timestamp("INFO","JSON-RPC Connection accepted from a client.");
 
-        if (parse_status == 0) {
-            // Successfully parsed the request
-            double result = 0.0;
-            const char *error_message = NULL; // No error initially
+            memset(buffer, 0, BUFFER_SIZE);
+            ssize_t bytes_read = read(client_fd, buffer, BUFFER_SIZE - 1);
 
-            // Log the parsed request details
-            printf("Parsed request: method='%s', params=[%f, %f], id=%d\n", method, params[0], params[1], id);
+            if (bytes_read < 0) {
+                char err_msg[256];
+                snprintf(err_msg, sizeof(err_msg), "Read from JSON-RPC client failed: %s", strerror(errno));
+                perror("read from JSON-RPC client failed");
+                log_with_timestamp("ERROR", err_msg);
+                close(client_fd);
+                continue;
+            }
+            if (bytes_read == 0) {
+                log_with_timestamp("INFO", "JSON-RPC client disconnected gracefully (read 0 bytes).");
+                close(client_fd);
+                continue;
+            }
+            buffer[bytes_read] = '\0';
+            snprintf(log_buf, sizeof(log_buf), "Received JSON-RPC request: %s", buffer);
+            log_with_timestamp("DEBUG", log_buf);
 
-            // Call appropriate calculator function based on the parsed method
-            if (strcmp(method, "add") == 0) {
-                result = add(params[0], params[1]);
-            } else if (strcmp(method, "subtract") == 0) {
-                result = subtract(params[0], params[1]);
-            } else if (strcmp(method, "multiply") == 0) {
-                result = multiply(params[0], params[1]);
-            } else if (strcmp(method, "divide") == 0) {
-                if (params[1] == 0.0) { // Check for division by zero explicitly
-                    error_message = "Division by zero";
+            char method[256];
+            double params[2];
+            int id = -1;
+            int parse_status = parse_json_rpc_request(buffer, method, params, &id);
+            char response_str[BUFFER_SIZE];
+            memset(response_str, 0, BUFFER_SIZE);
+
+            if (parse_status == 0) {
+                const char *error_message = NULL;
+
+                char chosen_backend_name[100] = "N/A";
+                RegisteredBackend* selected_backend = select_backend(method, chosen_backend_name, sizeof(chosen_backend_name));
+
+                if (selected_backend == NULL) {
+                    snprintf(log_buf, sizeof(log_buf), "Method '%s' (id: %d) not supported by any available backend or no backends available.", method, id);
+                    log_with_timestamp("ERROR", log_buf);
+                    error_message = "Method not supported by any available backend or no backends available.";
+                    build_json_rpc_response(response_str, id, 0.0, error_message);
                 } else {
-                    result = divide(params[0], params[1]);
+                    snprintf(log_buf, sizeof(log_buf), "Routing request for method '%s' (id: %d) to backend: %s (%s:%d)",
+                             method, id, selected_backend->name, selected_backend->host, selected_backend->port);
+                    log_with_timestamp("INFO", log_buf);
+
+                    int op_code = get_backend_op_code(method);
+                    if (op_code == 0) {
+                        error_message = "Internal server error: Method mapped to unknown operation code.";
+                        snprintf(log_buf, sizeof(log_buf), "Method '%s' (id: %d) mapped to op_code 0. This indicates an issue with is_operation_supported or get_backend_op_code logic.", method, id);
+                        log_with_timestamp("CRITICAL", log_buf);
+                        build_json_rpc_response(response_str, id, 0.0, error_message);
+                    } else {
+                        char backend_request_str[256];
+                        sprintf(backend_request_str, "%d %lf %lf", op_code, params[0], params[1]);
+
+                        char backend_response_str[1024] = {0};
+                        int communication_status = -1;
+
+                        if (strcmp(selected_backend->type, "TCP") == 0) {
+                            communication_status = communicate_with_tcp_backend(selected_backend, backend_request_str, backend_response_str, sizeof(backend_response_str));
+                        } else if (strcmp(selected_backend->type, "UDP") == 0) {
+                            communication_status = communicate_with_udp_backend(selected_backend, backend_request_str, backend_response_str, sizeof(backend_response_str));
+                        } else {
+                            snprintf(log_buf, sizeof(log_buf), "Unknown backend type '%s' for backend %s (id: %d)", selected_backend->type, selected_backend->name, id);
+                            log_with_timestamp("ERROR", log_buf);
+                            error_message = "Internal server error: Unknown backend type configured.";
+                        }
+
+                        if (error_message == NULL) {
+                            double backend_result = 0.0;
+                            char backend_error_msg[BUFFER_SIZE] = {0};
+                            const char* final_error_message_ptr = NULL;
+
+                            if (communication_status != 0) {
+                                snprintf(log_buf, sizeof(log_buf), "Error communicating with backend %s (id: %d): %s", selected_backend->name, id, backend_response_str);
+                                log_with_timestamp("ERROR", log_buf);
+                                final_error_message_ptr = backend_response_str;
+                            } else {
+                                snprintf(log_buf, sizeof(log_buf), "Raw response from backend %s (id: %d): \"%s\"", selected_backend->name, id, backend_response_str);
+                                log_with_timestamp("INFO", log_buf);
+                                int parse_res_status = parse_backend_response(backend_response_str, &backend_result, backend_error_msg, sizeof(backend_error_msg));
+
+                                if (parse_res_status == 0) {
+                                } else if (parse_res_status == 1) {
+                                    final_error_message_ptr = backend_error_msg;
+                                } else {
+                                    final_error_message_ptr = backend_error_msg;
+                                }
+                            }
+                            build_json_rpc_response(response_str, id, backend_result, final_error_message_ptr);
+                        } else {
+                             build_json_rpc_response(response_str, id, 0.0, error_message);
+                        }
+                    }
                 }
             } else {
-                // Method name does not match any implemented function
-                error_message = "Method not found";
+                snprintf(log_buf, sizeof(log_buf), "Failed to parse JSON-RPC request (id: %d). Body: %s", id, buffer);
+                log_with_timestamp("ERROR", log_buf);
+                build_json_rpc_response(response_str, id, 0.0, "Parse error. Invalid JSON-RPC request.");
             }
 
-            // Build the JSON-RPC response (success or error from method execution)
-            build_json_rpc_response(response_str, id, result, error_message);
-
-        } else {
-            // Parsing failed; build an error response.
-            // The 'id' might not be parsed correctly if the JSON is malformed.
-            // If parse_status is an error, 'id' might hold the initialized -1 or a partially parsed value.
-            // JSON-RPC spec suggests responding with null id if request id cannot be determined.
-            // Our parser sets id to -1 if it can't find/parse it.
-            fprintf(stderr, "Failed to parse JSON-RPC request. Request body: %s\n", buffer);
-            // The 'id' from parse_json_rpc_request will be used; if it wasn't parsed, it remains -1.
-            build_json_rpc_response(response_str, id, 0.0, "Parse error. Invalid JSON-RPC request.");
+            snprintf(log_buf, sizeof(log_buf), "Sending JSON-RPC response (id: %d): %s", id, response_str);
+            log_with_timestamp("DEBUG", log_buf);
+            if (write(client_fd, response_str, strlen(response_str)) < 0) {
+                char err_msg[256];
+                snprintf(err_msg, sizeof(err_msg), "Write to JSON-RPC client failed (id: %d): %s", id, strerror(errno));
+                perror("write to JSON-RPC client failed");
+                log_with_timestamp("ERROR", err_msg);
+            }
+            close(client_fd);
+            log_with_timestamp("INFO", "JSON-RPC Connection closed.");
         }
-
-        printf("Sending response: %s\n", response_str);
-        // Send the response string back to the client
-        if (write(client_fd, response_str, strlen(response_str)) < 0) {
-            perror("write to client failed");
-        }
-
-        // Close the client socket after sending the response
-        close(client_fd);
-        printf("Connection closed for the client.\n\n");
-        // Buffer is cleared at the start of the loop for the next request.
     }
 
-    // Close the listening server socket (this part is typically not reached in a simple infinite loop server without signal handling)
-    printf("Shutting down server.\n"); // This line is more aspirational without signal handling
+    log_with_timestamp("INFO", "Shutting down server.");
     close(server_fd);
+    close(discovery_fd);
     return 0;
 }
 
-// Basic calculator function implementations
-// These are simple arithmetic operations.
-double add(double a, double b) {
-    return a + b;
-}
+double add(double a, double b) { return a + b; }
+double subtract(double a, double b) { return a - b; }
+double multiply(double a, double b) { return a * b; }
+double divide(double a, double b) { return a / b; } // Basic, assumes caller checks for b==0 based on error_message
 
-double subtract(double a, double b) {
-    return a - b;
-}
-
-double multiply(double a, double b) {
-    return a * b;
-}
-
-double divide(double a, double b) {
-    // Error handling for division by zero will be in the main logic
-    return a / b;
-}
-
-// Implementation for parse_json_rpc_request
-// This is a simplified parser. A robust parser would ideally use a dedicated JSON library.
-// It assumes a well-structured request like:
-// {"jsonrpc": "2.0", "method": "subtract", "params": [42.0, 23.0], "id": 1}
-// Or for notifications (id may be absent, or null - this parser expects an int id or fails):
-// {"jsonrpc": "2.0", "method": "update", "params": [1,2,3,4,5]}
 int parse_json_rpc_request(const char *json_str, char *method, double *params, int *id) {
     if (json_str == NULL || method == NULL || params == NULL || id == NULL) {
-        return -1; // Null pointers passed
+        log_with_timestamp("CRITICAL", "NULL argument to parse_json_rpc_request");
+        return -1;
     }
+    *id = -1;
 
-    // Find "method"
+    char log_buf[BUFFER_SIZE + 50];
     const char *method_key = "\"method\": \"";
     const char *method_start = strstr(json_str, method_key);
     if (method_start == NULL) {
-        fprintf(stderr, "Parse error: method key not found\n");
+        snprintf(log_buf, sizeof(log_buf), "Parse error: method key not found in request: %.1000s", json_str);
+        log_with_timestamp("ERROR", log_buf);
         return -1;
     }
     method_start += strlen(method_key);
     const char *method_end = strchr(method_start, '\"');
-    if (method_end == NULL || (method_end - method_start) >= 256) { // 256 is buffer size for method
-        fprintf(stderr, "Parse error: method value not found or too long\n");
+    if (method_end == NULL || (size_t)(method_end - method_start) >= 256 ) {
+        snprintf(log_buf, sizeof(log_buf), "Parse error: method value not found or too long in request: %.1000s", json_str);
+        log_with_timestamp("ERROR", log_buf);
         return -1;
     }
     strncpy(method, method_start, method_end - method_start);
     method[method_end - method_start] = '\0';
 
-    // Find "params"
     const char *params_key = "\"params\": [";
     const char *params_start = strstr(json_str, params_key);
     if (params_start == NULL) {
-        fprintf(stderr, "Parse error: params key not found\n");
+        snprintf(log_buf, sizeof(log_buf), "Parse error: params key not found for method '%s' in request: %.1000s", method, json_str);
+        log_with_timestamp("ERROR", log_buf);
         return -1;
     }
     params_start += strlen(params_key);
-    // Use sscanf to parse the two double parameters
-    // This is fragile; it assumes exactly two numbers and specific formatting.
-    if (sscanf(params_start, "%lf, %lf]", &params[0], &params[1]) != 2) {
-        // Try parsing with optional space after comma
-        if (sscanf(params_start, "%lf, %lf]", &params[0], &params[1]) != 2 && sscanf(params_start, "%lf,%lf]", &params[0], &params[1]) !=2) {
-            fprintf(stderr, "Parse error: could not parse params array\n");
-            return -1;
-        }
+    if (sscanf(params_start, "%lf, %lf]", &params[0], &params[1]) != 2 &&
+        sscanf(params_start, "%lf,%lf]", &params[0], &params[1]) != 2) {
+        snprintf(log_buf, sizeof(log_buf), "Parse error: could not parse params array for method '%s' in request: %.1000s", method, json_str);
+        log_with_timestamp("ERROR", log_buf);
+        return -1;
     }
 
-    // Find "id"
-    // It could be at the end or before/after other fields.
-    // This parser assumes id is an integer. JSON-RPC allows string or null ids too.
     const char *id_key = "\"id\": ";
     const char *id_start = strstr(json_str, id_key);
     if (id_start == NULL) {
-        // Check if it's a notification (id is optional or null)
-        // This basic parser will consider missing ID an error for simplicity,
-        // as the main loop expects an ID to build a response.
-        // A more robust server might handle notifications differently (no response).
-        fprintf(stderr, "Parse error: id key not found\n");
+        snprintf(log_buf, sizeof(log_buf), "Parse error: id key not found for method '%s'. Request: %.1000s", method, json_str);
+        log_with_timestamp("ERROR", log_buf);
         return -1;
     }
     id_start += strlen(id_key);
-    // Use sscanf to parse the integer ID
     if (sscanf(id_start, "%d", id) != 1) {
-        fprintf(stderr, "Parse error: could not parse id\n");
+        char temp_id_str[128];
+        if (sscanf(id_start, "\"%127[^\"]\"", temp_id_str) == 1) {
+             snprintf(log_buf, sizeof(log_buf), "Parse warning: id is a string (\"%s\") but only integer IDs are supported. Method '%s'. Treating as parse error for ID. Request: %.1000s", temp_id_str, method, json_str);
+             log_with_timestamp("WARNING", log_buf);
+        } else if (strncmp(id_start, "null", 4) == 0) {
+             snprintf(log_buf, sizeof(log_buf), "Parse warning: id is null. Method '%s'. Treating as parse error for ID. Request: %.1000s", method, json_str);
+             log_with_timestamp("WARNING", log_buf);
+        } else {
+            snprintf(log_buf, sizeof(log_buf), "Parse error: could not parse id as integer for method '%s'. Request: %.1000s", method, json_str);
+            log_with_timestamp("ERROR", log_buf);
+        }
+        *id = -1; // Ensure id is -1 on any parsing failure for it
         return -1;
     }
-
-    return 0; // Success
+    return 0;
 }
 
-// Implementation for build_json_rpc_response
 void build_json_rpc_response(char *response_str, int id, double result, const char *error_message) {
-    if (response_str == NULL) return;
+    if (response_str == NULL) {
+        log_with_timestamp("CRITICAL", "build_json_rpc_response called with NULL response_str");
+        return;
+    }
+    char temp_buf[BUFFER_SIZE];
 
     if (error_message) {
-        // According to JSON-RPC 2.0 spec, error object has code and message
-        // Using a generic error code for simplicity here.
-        // "message" should be a string, so needs to be in quotes.
-        sprintf(response_str, "{\"jsonrpc\": \"2.0\", \"error\": {\"code\": -32000, \"message\": \"%s\"}, \"id\": %d}", error_message, id);
+        char escaped_error_message[sizeof(temp_buf)];
+        char *p_esc = escaped_error_message;
+        const char *p_err = error_message;
+        size_t available_space = sizeof(escaped_error_message) -1;
+
+        while (*p_err && available_space > 0) {
+            if (*p_err == '"') {
+                if (available_space < 2) break;
+                *p_esc++ = '\\';
+                *p_esc++ = '"';
+                available_space -= 2;
+            } else if (*p_err == '\\') {
+                 if (available_space < 2) break;
+                *p_esc++ = '\\';
+                *p_esc++ = '\\';
+                available_space -= 2;
+            }
+            else {
+                *p_esc++ = *p_err;
+                available_space--;
+            }
+            p_err++;
+        }
+        *p_esc = '\0';
+
+        if (id == -1) {
+            snprintf(temp_buf, sizeof(temp_buf), "{\"jsonrpc\": \"2.0\", \"error\": {\"code\": -32700, \"message\": \"%s\"}, \"id\": null}", escaped_error_message);
+        } else {
+            snprintf(temp_buf, sizeof(temp_buf), "{\"jsonrpc\": \"2.0\", \"error\": {\"code\": -32000, \"message\": \"%s\"}, \"id\": %d}", escaped_error_message, id);
+        }
     } else {
-        // Result also needs to follow JSON format (number for result here)
-        sprintf(response_str, "{\"jsonrpc\": \"2.0\", \"result\": %f, \"id\": %d}", result, id);
+         if (id == -1) {
+            log_with_timestamp("WARNING", "Building successful JSON-RPC response but request ID was -1 (likely parse error). Sending id as null.");
+            snprintf(temp_buf, sizeof(temp_buf), "{\"jsonrpc\": \"2.0\", \"result\": %f, \"id\": null}", result);
+         } else {
+            snprintf(temp_buf, sizeof(temp_buf), "{\"jsonrpc\": \"2.0\", \"result\": %f, \"id\": %d}", result, id);
+         }
     }
+    strncpy(response_str, temp_buf, BUFFER_SIZE -1);
+    response_str[BUFFER_SIZE -1] = '\0';
 }


### PR DESCRIPTION
The json_rpc/server now functions as a distributed gateway, launching and managing backend calculator server processes.

Key features:
- Process Management: Reads `json_rpc/backends.conf` to determine which backend servers (e.g., ../concurrent_tcp_async/server) to launch and manage. Includes basic auto-relaunch on exit.
- Service Discovery: Backend servers register with me via UDP messages upon startup, advertising their type, address, port, name, and supported operations. I listen for these registrations.
- Dynamic Routing: Your JSON-RPC requests are routed to an appropriate, registered backend server based on the requested operation using a round-robin strategy for load distribution.
- Protocol Translation: I translate JSON-RPC requests to the simple text-based protocol of the backend servers and translate their responses back to JSON-RPC.
- Backend Server Modifications: Example backend servers (concurrent_tcp_async, iterative_udp) were updated to support command-line configuration and gateway registration.
- Documentation: Added `json_rpc/DISTRIBUTED_SETUP.md` explaining the new architecture, setup, and usage.

This change significantly refactors the JSON-RPC server from a monolithic application to a proxy/gateway in a distributed RPC environment.